### PR TITLE
fix OS X <= 10.9 build

### DIFF
--- a/src/mulle-xcode-to-cmake/NSString+ExternalName.m
+++ b/src/mulle-xcode-to-cmake/NSString+ExternalName.m
@@ -33,7 +33,7 @@
          s = [[s componentsSeparatedByString:@"OSFoundation"] componentsJoinedByString:@"OsFoundation"];
    }
    else
-#else
+#endif
    {
       if( [s rangeOfString:@"MulleObjC"].length)
          s = [[s componentsSeparatedByString:@"MulleObjC"] componentsJoinedByString:@"MulleObjc"];
@@ -42,7 +42,6 @@
       if( [s rangeOfString:@"OSFoundation"].length)
          s = [[s componentsSeparatedByString:@"OSFoundation"] componentsJoinedByString:@"OsFoundation"];
    }
-#endif
 
    result = [NSMutableString string];
    set    = [NSCharacterSet uppercaseLetterCharacterSet];


### PR DESCRIPTION
I messed up the platform selection logic in `[NSString externalNameForInternalName:]` which broke building on legacy OS X versions.
This is a fix.