### PR TITLE
Fixed broken execute_process() call under GNUstep shell on Windows

### DIFF
--- a/BUILD-GNUSTEP-WINDOWS.md
+++ b/BUILD-GNUSTEP-WINDOWS.md
@@ -1,0 +1,38 @@
+On Windows, using GNUstep shell and CMake, the build fails at link-time with the following type of error : 
+
+```
+undefined reference to objc_get_class 
+```
+
+The executed command by CMake is the following : 
+
+```
+/C/GNUstep/bin/gcc.exe    -Wl,--enable-auto-import -shared-libgcc -fexceptions -fgnu-runtime -L/usr/home/user/GNUstep/Library/Libraries -L/GNUstep/Local/Library/Libraries -L/GNUstep/System/Library/Libraries -lgnustep-base -lobjc -lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 -lmpr -lnetapi32 -lm -I. -Wl,--whole-archive CMakeFiles/mulle-xcode-to-cmake.dir/objects.a -Wl,--no-whole-archive -Wl,--whole-archive libmullepbx.a -Wl,--no-whole-archive -o mulle-xcode-to-cmake.exe -Wl,--out-implib,libmulle-xcode-to-cmake.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/mulle-xcode-to-cmake.dir/linklibs.rsp
+```
+
+As we can see, gcc is called with the linked libraries appearing first (-l...), then the sources appearing after them (.a).
+This leads to the libraries not being linked, as the symbols in them are not yet encountered.
+Using ```-Wl,--no-as-needed``` does not fix the problem.
+
+The following manual solution fixes the issue : 
+
+1 / Run CMake from the build directory:
+
+```
+         i.e. mkdir build && cd build 
+         cmake -G"MSYS Makefiles" .. -Wno-dev -DCMAKE_VERBOSE_MAKEFILE=ON
+```
+
+2 / Go to CMakeFiles/mulle-xcode-to-cmake.dir in the build directory
+
+3 / Open build.make 
+
+4 / Find the last gcc call. Make sure to have .a appear before -l, something like the following : 
+
+```
+/C/GNUstep/bin/gcc.exe -Wl,--whole-archive CMakeFiles/mulle-xcode-to-cmake.dir/objects.a -Wl,--no-whole-archive -Wl,--whole-archive libmullepbx.a -Wl,--no-whole-archive   -Wl,--enable-auto-import -shared-libgcc -fexceptions -fgnu-runtime -L/usr/home/user/GNUstep/Library/Libraries -L/GNUstep/Local/Library/Libraries -L/GNUstep/System/Library/Libraries -lgnustep-base -lobjc -lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 -lmpr -lnetapi32 -lm -I.  -o mulle-xcode-to-cmake.exe -Wl,--out-implib,libmulle-xcode-to-cmake.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/mulle-xcode-to-cmake.dir/linklibs.rsp
+```
+
+5 / Open linklibs.rsp and delete libmullepbx.a 
+
+6 / Now, call ```make```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,21 @@ if(APPLE)
     find_library( FOUNDATION_LIBRARY Foundation)
     message( STATUS "FOUNDATION_LIBRARY is ${FOUNDATION_LIBRARY}")
 else()
+
+	# Without this, execute_process() does not work under GNUstep shell on Windows
+	# =>  	objc_def_flags and objc_def_link_flags are empty 
+	# =>	RESULT_VARIABLE contains "%1 is not a valid win32 app"
+	if(WIN32)
+		set(EXECUTE_PROCESS_PRECOMMAND "sh")
+	endif()
+
     find_program(GNUstepConfig "gnustep-config")
     if(GNUstepConfig)
         message(STATUS "Using GNUstep (${GNUstepConfig})")
-        execute_process(COMMAND "${GNUstepConfig}" "--objc-flags"
+        execute_process(COMMAND ${EXECUTE_PROCESS_PRECOMMAND} "${GNUstepConfig}" "--objc-flags"
             OUTPUT_VARIABLE objc_def_flags
             OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND "${GNUstepConfig}" "--base-libs"
+        execute_process(COMMAND ${EXECUTE_PROCESS_PRECOMMAND} "${GNUstepConfig}" "--base-libs"
             OUTPUT_VARIABLE objc_def_link_flags
             OUTPUT_STRIP_TRAILING_WHITESPACE)
         set(objc_flags      "${objc_def_flags}")

--- a/README.md
+++ b/README.md
@@ -45,6 +45,43 @@ platforms it is suggested to install a recent clang version (5 or later) and you
 will need libobjc and the gnustep-base developer package, both from GNUstep (or another
 implementation of the ObjC runtime and the Foundation library).
 
+On Windows, using GNUstep shell, the build fails at link-time with the following type of errors : 
+
+```
+undefined reference to objc_get_class 
+```
+
+The executed command is the following : 
+
+```
+/C/GNUstep/bin/gcc.exe    -Wl,--enable-auto-import -shared-libgcc -fexceptions -fgnu-runtime -L/usr/home/user/GNUstep/Library/Libraries -L/GNUstep/Local/Library/Libraries -L/GNUstep/System/Library/Libraries -lgnustep-base -lobjc -lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 -lmpr -lnetapi32 -lm -I. -Wl,--whole-archive CMakeFiles/mulle-xcode-to-cmake.dir/objects.a -Wl,--no-whole-archive -Wl,--whole-archive libmullepbx.a -Wl,--no-whole-archive -o mulle-xcode-to-cmake.exe -Wl,--out-implib,libmulle-xcode-to-cmake.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/mulle-xcode-to-cmake.dir/linklibs.rsp
+```
+
+As we can see, gcc is called with the linked libraries appearing first (-l...), then the source appearing after them (.a).
+This leads to the libraries not being linked, as the symbols in the libraries are not yet encountered.
+Using ```-Wl,--no-as-needed``` does not fix the problem.
+
+The following manual solution fixes the issue : 
+
+1 / Run cmake :
+
+```
+         i.e. cmake -G"MSYS Makefiles" .. -Wno-dev -DCMAKE_VERBOSE_MAKEFILE=ON
+```
+
+2 / Go to build/CMakeFiles/mulle-xcode-to-cmake.dir
+
+3 / Open build.make 
+
+4 / Find the last gcc call. Make sure to have .a before -l, like the following : 
+
+```
+/C/GNUstep/bin/gcc.exe -Wl,--whole-archive CMakeFiles/mulle-xcode-to-cmake.dir/objects.a -Wl,--no-whole-archive -Wl,--whole-archive libmullepbx.a -Wl,--no-whole-archive   -Wl,--enable-auto-import -shared-libgcc -fexceptions -fgnu-runtime -L/usr/home/user/GNUstep/Library/Libraries -L/GNUstep/Local/Library/Libraries -L/GNUstep/System/Library/Libraries -lgnustep-base -lobjc -lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 -lmpr -lnetapi32 -lm -I.  -o mulle-xcode-to-cmake.exe -Wl,--out-implib,libmulle-xcode-to-cmake.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/mulle-xcode-to-cmake.dir/linklibs.rsp
+```
+
+5 / Open linklibs.rsp and delete libmullepbx.a 
+
+6 / Now, call ```make```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -45,43 +45,7 @@ platforms it is suggested to install a recent clang version (5 or later) and you
 will need libobjc and the gnustep-base developer package, both from GNUstep (or another
 implementation of the ObjC runtime and the Foundation library).
 
-On Windows, using GNUstep shell, the build fails at link-time with the following type of errors : 
-
-```
-undefined reference to objc_get_class 
-```
-
-The executed command is the following : 
-
-```
-/C/GNUstep/bin/gcc.exe    -Wl,--enable-auto-import -shared-libgcc -fexceptions -fgnu-runtime -L/usr/home/user/GNUstep/Library/Libraries -L/GNUstep/Local/Library/Libraries -L/GNUstep/System/Library/Libraries -lgnustep-base -lobjc -lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 -lmpr -lnetapi32 -lm -I. -Wl,--whole-archive CMakeFiles/mulle-xcode-to-cmake.dir/objects.a -Wl,--no-whole-archive -Wl,--whole-archive libmullepbx.a -Wl,--no-whole-archive -o mulle-xcode-to-cmake.exe -Wl,--out-implib,libmulle-xcode-to-cmake.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/mulle-xcode-to-cmake.dir/linklibs.rsp
-```
-
-As we can see, gcc is called with the linked libraries appearing first (-l...), then the source appearing after them (.a).
-This leads to the libraries not being linked, as the symbols in the libraries are not yet encountered.
-Using ```-Wl,--no-as-needed``` does not fix the problem.
-
-The following manual solution fixes the issue : 
-
-1 / Run cmake :
-
-```
-         i.e. cmake -G"MSYS Makefiles" .. -Wno-dev -DCMAKE_VERBOSE_MAKEFILE=ON
-```
-
-2 / Go to build/CMakeFiles/mulle-xcode-to-cmake.dir
-
-3 / Open build.make 
-
-4 / Find the last gcc call. Make sure to have .a before -l, like the following : 
-
-```
-/C/GNUstep/bin/gcc.exe -Wl,--whole-archive CMakeFiles/mulle-xcode-to-cmake.dir/objects.a -Wl,--no-whole-archive -Wl,--whole-archive libmullepbx.a -Wl,--no-whole-archive   -Wl,--enable-auto-import -shared-libgcc -fexceptions -fgnu-runtime -L/usr/home/user/GNUstep/Library/Libraries -L/GNUstep/Local/Library/Libraries -L/GNUstep/System/Library/Libraries -lgnustep-base -lobjc -lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 -lmpr -lnetapi32 -lm -I.  -o mulle-xcode-to-cmake.exe -Wl,--out-implib,libmulle-xcode-to-cmake.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles/mulle-xcode-to-cmake.dir/linklibs.rsp
-```
-
-5 / Open linklibs.rsp and delete libmullepbx.a 
-
-6 / Now, call ```make```
+On Windows, it is a bit tricky : please refer to this little guide [here](https://github.com/ElMostafaIdrassi/mulle-xcode-to-cmake/blob/release/BUILD-GNUSTEP-WINDOWS.md) 
 
 ## Usage
 


### PR DESCRIPTION
For gnustep-config bash script to be invoked properly by `execute_process()` under GNUstep shell on Windows, the `${GNUstepConfig}` call must preceded by `sh`. Otherwise, `execute_process()` fails, leading to `objc_def_flags` and `objc_def_link_flags` being empty, with `RESULT_VARIABLE` containing : `%1 is not a valid win32 application`.