### PR TITLE
Fix extra right peren syntax error for `set_target_properties`

### DIFF
--- a/src/mulle-xcode-to-cmake/main.m
+++ b/src/mulle-xcode-to-cmake/main.m
@@ -1028,7 +1028,7 @@ static void   export_target( PBXTarget *pbxtarget,
       printf( "\n"
               "set_target_properties( %s\n"
               "   PROPERTIES\n"
-              "   OUTPUT_NAME %s)\n"
+              "   OUTPUT_NAME %s\n"
               ")\n",
               ctxt3.s_target_name,
               ctxt.s_target_name);


### PR DESCRIPTION
Fixes https://github.com/mulle-nat/mulle-xcode-to-cmake/issues/14
